### PR TITLE
fix: add _wrap function and support multiple Moderation responses

### DIFF
--- a/src/opentelemetry/instrumentation/openai/__init__.py
+++ b/src/opentelemetry/instrumentation/openai/__init__.py
@@ -32,14 +32,15 @@ Instrument all OpenAI client calls:
         messages=[{"role": "user", "content": "tell me a joke about opentelemetry"}],
     )
 """
-import math
+import logging
 from typing import Collection
 
-import wrapt
+from wrapt import wrap_function_wrapper
 import openai
 
 from opentelemetry import context as context_api
-from opentelemetry.trace import get_tracer, Tracer, SpanKind
+from opentelemetry.trace import get_tracer, SpanKind
+from opentelemetry.trace.status import Status, StatusCode
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import (
@@ -50,525 +51,337 @@ from opentelemetry.instrumentation.openai.package import _instruments
 from opentelemetry.instrumentation.openai.version import __version__
 
 
-def _instrument_chat(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
+logger = logging.getLogger(__name__)
 
-        name = "openai.chat"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.model", kwargs["model"])
-            span.set_attribute(
-                f"{name}.temperature",
-                kwargs["temperature"] if "temperature" in kwargs else 1.0,
-            )
-            span.set_attribute(
-                f"{name}.top_p", kwargs["top_p"] if "top_p" in kwargs else 1.0
-            )
-            span.set_attribute(f"{name}.n", kwargs["n"] if "n" in kwargs else 1)
-            span.set_attribute(
-                f"{name}.stream", kwargs["stream"] if "stream" in kwargs else False
-            )
-            span.set_attribute(
-                f"{name}.stop", kwargs["stop"] if "stop" in kwargs else ""
-            )
-            span.set_attribute(
-                f"{name}.max_tokens",
-                kwargs["max_tokens"] if "max_tokens" in kwargs else math.inf,
-            )
-            span.set_attribute(
-                f"{name}.presence_penalty",
-                kwargs["presence_penalty"] if "presence_penalty" in kwargs else 0.0,
-            )
-            span.set_attribute(
-                f"{name}.frequency_penalty",
-                kwargs["frequency_penalty"] if "frequency_penalty" in kwargs else 0.0,
-            )
-            span.set_attribute(
-                f"{name}.logit_bias",
-                kwargs["logit_bias"] if "logit_bias" in kwargs else "",
-            )
-            span.set_attribute(
-                f"{name}.user", kwargs["user"] if "user" in kwargs else ""
-            )
-            for index, message in enumerate(kwargs["messages"]):
-                span.set_attribute(f"{name}.messages.{index}.role", message["role"])
+
+TO_WRAP = [
+    {
+        "object": "ChatCompletion",
+        "method": "create",
+        "span_name": "openai.chat",
+        "default_inputs": {
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "n": 1,
+            "stream": False,
+            "stop": "",
+            "max_tokens": float('inf'),
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "logit_bias": "",
+            "user": "",
+        }
+    },
+    {
+        "object": "Completion",
+        "method": "create",
+        "span_name": "openai.completion",
+        "default_inputs": {
+            "suffix": "",
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "n": 1,
+            "stream": False,
+            "logprobs": -1,
+            "echo": False,
+            "stop": "",
+            "max_tokens": float('inf'),
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "best_of": 1,
+            "logit_bias": "",
+            "user": "",
+        }
+    },
+    {
+        "object": "Embedding",
+        "method": "create",
+        "span_name": "openai.embedding",
+        "default_inputs": {
+            "user": "",
+        }
+    },
+    {
+        "object": "Edit",
+        "method": "create",
+        "span_name": "openai.edit",
+        "default_inputs": {
+            "input": "",
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "n": 1,
+        }
+    },
+    {
+        "object": "Moderation",
+        "method": "create",
+        "span_name": "openai.moderation",
+        "default_inputs": {
+            "model": "text-moderation-latest"
+        }
+    },
+    {
+        "object": "Image",
+        "method": "create",
+        "span_name": "openai.image.generate",
+        "default_inputs": {
+            "n": 1,
+            "size": "1024x1024",
+            "response_format": "url",
+            "user": "",
+        }
+    },
+    {
+        "object": "Image",
+        "method": "create_edit",
+        "span_name": "openai.image.edit",
+        "default_inputs": {
+            "mask": "",
+            "n": 1,
+            "size": "1024x1024",
+            "response_format": "url",
+            "user": "",
+        }
+    },
+    {
+        "object": "Image",
+        "method": "create_variation",
+        "span_name": "openai.image.variation",
+        "default_inputs": {
+            "n": 1,
+            "size": "1024x1024",
+            "response_format": "url",
+            "user": "",
+        }
+    },
+    {
+        "object": "Audio",
+        "method": "transcribe",
+        "span_name": "openai.audio.transcribe",
+        "default_inputs": {
+            "prompt": "",
+            "response_format": "json",
+            "temperature": 0.0,
+            "language": "",
+        }
+    },
+    {
+        "object": "Audio",
+        "method": "translate",
+        "span_name": "openai.audio.translate",
+        "default_inputs": {
+            "prompt": "",
+            "response_format": "json",
+            "temperature": 0.0,
+        }
+    }
+]
+
+
+def no_none(value):
+    """
+    OTEL Attributes cannot be NoneType. 
+    If NoneType return string 'None'.
+    """
+    if value is None:
+        return str(value)
+    return value
+
+
+def _set_attributes(span, name, attributes, nestings=[]):
+    """
+    For every nested field, set its fields as attributes.
+    Then set the remianing non-nested fields. 
+    """
+    attr_copy = attributes.copy()  # don't change shape of inputs!
+    for nesting in nestings:
+        nested = attr_copy.pop(nesting, None)
+        if nested:
+            for key, value in nested.items():
                 span.set_attribute(
-                    f"{name}.messages.{index}.content", message["content"]
+                    f"{name}.{nesting}.{key}",
+                    no_none(value)
                 )
+    for key, value in attr_copy.items():
+        span.set_attribute(
+            f"{name}.{key}",
+            no_none(value)
+        )
+    return
 
-            response = wrapped(*args, **kwargs)
 
-            span.set_attribute(f"{name}.response.id", response["id"])
-            span.set_attribute(f"{name}.response.object", response["object"])
-            span.set_attribute(f"{name}.response.created", response["created"])
-            for index, choice in enumerate(response["choices"]):
-                span.set_attribute(
-                    f"{name}.response.choices.{index}.message.role",
-                    choice["message"]["role"],
+def _set_attributes_from_array(span, name, attributes, array_field, nestings=[]):
+    """
+    For a given field that contains arrays of fields, set each index's
+    fields as a unique set of attributes.
+    """
+    attr_array = attributes.pop(array_field, None)
+    if attr_array:
+        for index, attr_item in enumerate(attr_array):
+            _set_attributes(
+                span=span,
+                name=f"{name}.{array_field}.{index}",
+                attributes=attr_item,
+                nestings=nestings
+            )
+    return
+
+
+def _set_input_attributes(span, name, to_wrap, kwargs):
+    """
+    Capture input params as span attributes. 
+    Unpacks 'message' input fields to separate attributes.
+    For embeddings, captures count of 'input' values.
+    """
+
+    params = to_wrap.get("default_inputs")
+    params.update(kwargs)
+
+    # "input" fields can be very large, so we handle them specially 
+    # depending on which api object they belong to. 
+    _input = params.pop("input", None)
+    if _input:
+        if name in ["openai.embedding"]:
+            # input values for Embedding objects can be too
+            # long so for that we only capture len(input)
+            span.set_attribute(
+                f"{name}.input_count",
+                len(_input)
+            )
+        else:
+            # but input values for other objects are interesting
+            span.set_attribute(
+                f"{name}.input",
+                no_none(_input)
+            )
+
+    # set attributes from input fields nested under arrays 
+    # {messages[]}
+    _set_attributes_from_array(
+        span=span,
+        name=name,
+        attributes=params,
+        array_field="messages"
+    )
+
+    # set attributes from remaining input fields
+    _set_attributes(
+        span=span,
+        name=name,
+        attributes=params
+    )
+    return
+
+
+def _set_response_attributes(span, name, response):
+    """
+    Captures response fields as span attributes. 
+    Unpacks 'choices', 'usage', and 'results' fields to separate attributes.
+    For embeddings, catpures count of data values instead of data.
+    Otherwise captures data values that are not b64_json.
+    """
+
+    resp_attributes = response.copy()
+
+    # "data" fields can be very large, so we handle them specially 
+    # depending on which api object they belong to. 
+    resp_data = resp_attributes.pop("data", None)
+    if resp_data:
+        if name in ["openai.embedding"]:
+            # data values for Embedding objects can be too
+            # long so for that we only capture len(data)
+            span.set_attribute(
+                f"{name}.response.embeddings_count",
+                len(resp_data)
+            )
+        else:
+            # but data values for other objects are interesting
+            for index, datum in enumerate(resp_data):
+                for key, value in datum.items():
+                    if key not in ["b64_json"]:
+                        # b64_json values are too big, skip them
+                        span.set_attribute(
+                            f"{name}.response.data.{index}.{key}",
+                            no_none(value)
+                        )
+
+    # set attributes from response fields nested under arrays 
+    # {choices[], results[]}
+    _set_attributes_from_array(
+        span=span,
+        name=f"{name}.response",
+        attributes=resp_attributes,
+        array_field="choices",
+        nestings=["message"]
+    )
+    _set_attributes_from_array(
+        span=span,
+        name=f"{name}.response",
+        attributes=resp_attributes,
+        array_field="results",
+        nestings=["categories", "category_scores"]
+    )
+
+    # set attributes from remaining response fields
+    _set_attributes(
+        span=span,
+        name=f"{name}.response",
+        attributes=resp_attributes,
+        nestings=["usage"]
+    )
+    return
+
+
+def _with_tracer_wrapper(func):
+    """Helper for providing tracer for wrapper functions."""
+
+    def _with_tracer(tracer, to_wrap):
+        def wrapper(wrapped, instance, args, kwargs):
+            # prevent double wrapping
+            if hasattr(wrapped, "__wrapped__"):
+                return wrapped(*args, **kwargs)
+
+            return func(tracer, to_wrap, wrapped, instance, args, kwargs)
+
+        return wrapper
+
+    return _with_tracer
+
+
+@_with_tracer_wrapper
+def _wrap(tracer, to_wrap, wrapped, instance, args, kwargs):
+    """Instruments and calls every function defined in TO_WRAP."""
+    if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+        return wrapped(*args, **kwargs)
+
+    name = to_wrap.get("span_name")
+    with tracer.start_as_current_span(
+        name, kind=SpanKind.CLIENT, attributes={}
+    ) as span:
+        try:
+            if span.is_recording():
+                _set_input_attributes(span, name, to_wrap, kwargs)
+
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.warning(
+                "Failed to set input attributes for openai span, error: %s", 
+                str(ex)
+            )
+
+        response = wrapped(*args, **kwargs)
+
+        if response:
+            try:
+                _set_response_attributes(span, name, response)
+
+            except Exception as ex:  # pylint: disable=broad-except
+                logger.warning(
+                    "Failed to set response attributes for openai span, error: %s", 
+                    str(ex)
                 )
-                span.set_attribute(
-                    f"{name}.response.choices.{index}.message.content",
-                    choice["message"]["content"],
-                )
-                span.set_attribute(
-                    f"{name}.response.choices.{index}.finish_reason",
-                    choice["finish_reason"],
-                )
-
-            span.set_attribute(
-                f"{name}.response.usage.prompt_tokens",
-                response["usage"]["prompt_tokens"],
-            )
-            span.set_attribute(
-                f"{name}.response.usage.completion_tokens",
-                response["usage"]["completion_tokens"],
-            )
-            span.set_attribute(
-                f"{name}.response.usage.total_tokens", response["usage"]["total_tokens"]
-            )
-
+            span.set_status(Status(StatusCode.OK))
+            
         return response
-
-    wrapt.wrap_function_wrapper(openai.ChatCompletion, "create", _instrumented_create)
-
-
-def _instrument_embedding(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.embedding"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            print(kwargs)
-            span.set_attribute(f"{name}.model", kwargs["model"])
-            span.set_attribute(f"{name}.input_count", len(kwargs["input"]))
-            span.set_attribute(
-                f"{name}.user", kwargs["user"] if "user" in kwargs else ""
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.embeddings_count", len(response.data))
-            span.set_attribute(
-                f"{name}.response.usage.prompt_tokens", response.usage.prompt_tokens
-            )
-            span.set_attribute(
-                f"{name}.response.usage.total_tokens", response.usage.total_tokens
-            )
-
-    wrapt.wrap_function_wrapper(openai.Embedding, "create", _instrumented_create)
-
-
-def _instrument_completions(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.completion"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.model", kwargs["model"])
-            if "prompt" in kwargs:
-                if type(kwargs["prompt"]) == str:
-                    span.set_attribute(f"{name}.prompt", kwargs["prompt"])
-                else:
-                    for index, prompt in enumerate(kwargs["prompt"]):
-                        span.set_attribute(f"{name}.prompt.{index}", prompt)
-            span.set_attribute(
-                f"{name}.suffix",
-                kwargs["suffix"] if "suffix" in kwargs else "",
-            )
-            span.set_attribute(
-                f"{name}.temperature",
-                kwargs["temperature"] if "temperature" in kwargs else 1.0,
-            )
-            span.set_attribute(
-                f"{name}.top_p", kwargs["top_p"] if "top_p" in kwargs else 1.0
-            )
-            span.set_attribute(f"{name}.n", kwargs["n"] if "n" in kwargs else 1)
-            span.set_attribute(
-                f"{name}.stream", kwargs["stream"] if "stream" in kwargs else False
-            )
-            # TODO: logprobs is optional, not a concept in otel?
-            if "logprobs" in kwargs and kwargs["logprobs"] is not None:
-                span.set_attribute(
-                    f"{name}.logprobs",
-                    kwargs["logprobs"] if "logprobs" in kwargs else -1,
-                )
-            span.set_attribute(
-                f"{name}.echo", kwargs["echo"] if "echo" in kwargs else False
-            )
-            span.set_attribute(
-                f"{name}.stop", kwargs["stop"] if "stop" in kwargs else ""
-            )
-            span.set_attribute(
-                f"{name}.max_tokens",
-                kwargs["max_tokens"] if "max_tokens" in kwargs else math.inf,
-            )
-            span.set_attribute(
-                f"{name}.presence_penalty",
-                kwargs["presence_penalty"] if "presence_penalty" in kwargs else 0.0,
-            )
-            span.set_attribute(
-                f"{name}.frequency_penalty",
-                kwargs["frequency_penalty"] if "frequency_penalty" in kwargs else 0.0,
-            )
-            span.set_attribute(
-                f"{name}.best_of", kwargs["best_of"] if "best_of" in kwargs else 1
-            )
-            span.set_attribute(
-                f"{name}.logit_bias",
-                kwargs["logit_bias"] if "logit_bias" in kwargs else "",
-            )
-            span.set_attribute(
-                f"{name}.user", kwargs["user"] if "user" in kwargs else ""
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.id", response["id"])
-            span.set_attribute(f"{name}.response.object", response["object"])
-            span.set_attribute(f"{name}.response.created", response["created"])
-            for index, choice in enumerate(response["choices"]):
-                span.set_attribute(
-                    f"{name}.response.choices.{index}.text",
-                    choice["text"],
-                )
-                # TODO: logprobs is optional, not a concept in otel?
-                if choice["logprobs"] is not None:
-                    span.set_attribute(
-                        f"{name}.response.choices.{index}.logprobs",
-                        choice["logprobs"],
-                    )
-                span.set_attribute(
-                    f"{name}.response.choices.{index}.finish_reason",
-                    choice["finish_reason"],
-                )
-
-            span.set_attribute(
-                f"{name}.response.usage.prompt_tokens",
-                response["usage"]["prompt_tokens"],
-            )
-            span.set_attribute(
-                f"{name}.response.usage.completion_tokens",
-                response["usage"]["completion_tokens"],
-            )
-            span.set_attribute(
-                f"{name}.response.usage.total_tokens", response["usage"]["total_tokens"]
-            )
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Completion, "create", _instrumented_create)
-
-
-def _instrument_edit(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.edit"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.model", kwargs["model"])
-            span.set_attribute(f"{name}.instruction", kwargs["instruction"])
-            span.set_attribute(
-                f"{name}.input", kwargs["input"] if "input" in kwargs else ""
-            )
-            span.set_attribute(f"{name}.n", kwargs["n"] if "n" in kwargs else 1)
-            span.set_attribute(
-                f"{name}.temperature",
-                kwargs["temperature"] if "temperature" in kwargs else 1.0,
-            )
-            span.set_attribute(
-                f"{name}.top_p", kwargs["top_p"] if "top_p" in kwargs else 1.0
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.object", response["object"])
-            span.set_attribute(f"{name}.response.created", response["created"])
-            for index, choice in enumerate(response["choices"]):
-                span.set_attribute(
-                    f"{name}.response.choices.{index}.text", choice["text"]
-                )
-
-            span.set_attribute(
-                f"{name}.response.usage.prompt_tokens",
-                response["usage"]["prompt_tokens"],
-            )
-            span.set_attribute(
-                f"{name}.response.usage.completion_tokens",
-                response["usage"]["completion_tokens"],
-            )
-            span.set_attribute(
-                f"{name}.response.usage.total_tokens", response["usage"]["total_tokens"]
-            )
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Edit, "create", _instrumented_create)
-
-
-def _instrument_moderation(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.moderation"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(
-                f"{name}.model",
-                kwargs["model"] if "model" in kwargs else "text-moderation-latest",
-            )
-            span.set_attribute(f"{name}.input", kwargs["input"])
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.id", response["id"])
-            span.set_attribute(
-                f"{name}.response.results.categories.hate",
-                response["results"][0]["categories"]["hate"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.categories.hate/threatening",
-                response["results"][0]["categories"]["hate/threatening"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.categories.self-harm",
-                response["results"][0]["categories"]["self-harm"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.categories.sexual",
-                response["results"][0]["categories"]["sexual"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.categories.sexual/minors",
-                response["results"][0]["categories"]["sexual/minors"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.categories.violence",
-                response["results"][0]["categories"]["violence"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.categories.violence/graphic",
-                response["results"][0]["categories"]["violence/graphic"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.hate",
-                response["results"][0]["category_scores"]["hate"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.hate/threatening",
-                response["results"][0]["category_scores"]["hate/threatening"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.self-harm",
-                response["results"][0]["category_scores"]["self-harm"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.sexual",
-                response["results"][0]["category_scores"]["sexual"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.sexual/minors",
-                response["results"][0]["category_scores"]["sexual/minors"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.violence",
-                response["results"][0]["category_scores"]["violence"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.category_scores.violence/graphic",
-                response["results"][0]["category_scores"]["violence/graphic"],
-            )
-            span.set_attribute(
-                f"{name}.response.results.flagged", response["results"][0]["flagged"]
-            )
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Moderation, "create", _instrumented_create)
-
-
-def _instrument_image_generate(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.image.generate"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.prompt", kwargs["prompt"])
-            span.set_attribute(f"{name}.n", kwargs["n"] if "n" in kwargs else 1)
-            span.set_attribute(
-                f"{name}.size", kwargs["size"] if "size" in kwargs else "1024x1024"
-            )
-            span.set_attribute(
-                f"{name}.response_format",
-                kwargs["response_format"] if "response_format" in kwargs else "url",
-            )
-            span.set_attribute(
-                f"{name}.user", kwargs["user"] if "user" in kwargs else ""
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.created", response["created"])
-            for index, choice in enumerate(response["data"]):
-                if (
-                    "response_format" not in kwargs
-                    or kwargs["response_format"] == "url"
-                ):
-                    span.set_attribute(
-                        f"{name}.response.data.{index}.url", choice["url"]
-                    )
-                # Not going to instrument the b64_json response because it's huge
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Image, "create", _instrumented_create)
-
-
-def _instrument_image_edit(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return
-
-        name = "openai.image.edit"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.prompt", kwargs["prompt"])
-            span.set_attribute(f"{name}.image", kwargs["image"])
-            span.set_attribute(
-                f"{name}.mask", kwargs["mask"] if "mask" in kwargs else ""
-            )
-            span.set_attribute(f"{name}.n", kwargs["n"] if "n" in kwargs else 1)
-            span.set_attribute(
-                f"{name}.size", kwargs["size"] if "size" in kwargs else "1024x1024"
-            )
-            span.set_attribute(
-                f"{name}.response_format",
-                kwargs["response_format"] if "response_format" in kwargs else "url",
-            )
-            span.set_attribute(
-                f"{name}.user", kwargs["user"] if "user" in kwargs else ""
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.created", response["created"])
-            for index, choice in enumerate(response["data"]):
-                if (
-                    "response_format" not in kwargs
-                    or kwargs["response_format"] == "url"
-                ):
-                    span.set_attribute(
-                        f"{name}.response.data.{index}.url", choice["url"]
-                    )
-                # Not going to instrument the b64_json response because it's huge
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Image, "create_edit", _instrumented_create)
-
-
-def _instrument_image_variation(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.image.variation"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.image", kwargs["image"])
-            span.set_attribute(f"{name}.n", kwargs["n"] if "n" in kwargs else 1)
-            span.set_attribute(
-                f"{name}.size", kwargs["size"] if "size" in kwargs else "1024x1024"
-            )
-            span.set_attribute(
-                f"{name}.response_format",
-                kwargs["response_format"] if "response_format" in kwargs else "url",
-            )
-            span.set_attribute(
-                f"{name}.user", kwargs["user"] if "user" in kwargs else ""
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.created", response["created"])
-            for index, choice in enumerate(response["data"]):
-                if (
-                    "response_format" not in kwargs
-                    or kwargs["response_format"] == "url"
-                ):
-                    span.set_attribute(
-                        f"{name}.response.data.{index}.url", choice["url"]
-                    )
-                # Not going to instrument the b64_json response because it's huge
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Image, "create_variation", _instrumented_create)
-
-
-def _instrument_audio_transcription(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.audio.transcribe"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.file", kwargs["file"])
-            span.set_attribute(f"{name}.model", kwargs["model"])
-            span.set_attribute(
-                f"{name}.prompt", kwargs["prompt"] if "prompt" in kwargs else ""
-            )
-            span.set_attribute(
-                f"{name}.response_format",
-                kwargs["response_format"] if "response_format" in kwargs else "json",
-            )
-            span.set_attribute(
-                f"{name}.temperature",
-                kwargs["temperature"] if "temperature" in kwargs else 0.0,
-            )
-            span.set_attribute(
-                f"{name}.language", kwargs["language"] if "language" in kwargs else ""
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.text", response["text"])
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Audio, "transcribe", _instrumented_create)
-
-
-def _instrument_audio_translate(tracer: Tracer):
-    def _instrumented_create(wrapped, instance, args, kwargs):
-        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        name = "openai.audio.translate"
-        with tracer.start_as_current_span(name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute(f"{name}.file", kwargs["file"])
-            span.set_attribute(f"{name}.model", kwargs["model"])
-            span.set_attribute(
-                f"{name}.prompt", kwargs["prompt"] if "prompt" in kwargs else ""
-            )
-            span.set_attribute(
-                f"{name}.response_format",
-                kwargs["response_format"] if "response_format" in kwargs else "json",
-            )
-            span.set_attribute(
-                f"{name}.temperature",
-                kwargs["temperature"] if "temperature" in kwargs else 0.0,
-            )
-
-            response = wrapped(*args, **kwargs)
-
-            span.set_attribute(f"{name}.response.text", response["text"])
-
-        return response
-
-    wrapt.wrap_function_wrapper(openai.Audio, "translate", _instrumented_create)
 
 
 class OpenAIInstrumentor(BaseInstrumentor):
@@ -580,25 +393,19 @@ class OpenAIInstrumentor(BaseInstrumentor):
     def _instrument(self, **kwargs):
         tracer_provider = kwargs.get("tracer_provider")
         tracer = get_tracer(__name__, __version__, tracer_provider)
-        _instrument_chat(tracer)
-        _instrument_embedding(tracer)
-        _instrument_completions(tracer)
-        _instrument_edit(tracer)
-        _instrument_moderation(tracer)
-        _instrument_image_generate(tracer)
-        _instrument_image_edit(tracer)
-        _instrument_image_variation(tracer)
-        _instrument_audio_transcription(tracer)
-        _instrument_audio_translate(tracer)
+        for to_wrap in TO_WRAP:
+            wrap_object = to_wrap.get("object")
+            wrap_method = to_wrap.get("method")
+            wrap_function_wrapper(
+                "openai",
+                f"{wrap_object}.{wrap_method}",
+                _wrap(tracer, to_wrap)
+            )
 
     def _uninstrument(self, **kwargs):
-        unwrap(openai.ChatCompletion, "create")
-        unwrap(openai.Embedding, "create")
-        unwrap(openai.Completion, "create")
-        unwrap(openai.Edit, "create")
-        unwrap(openai.Moderation, "create")
-        unwrap(openai.Image, "create")
-        unwrap(openai.Image, "create_edit")
-        unwrap(openai.Image, "create_variation")
-        unwrap(openai.Audio, "transcribe")
-        unwrap(openai.Audio, "translate")
+        for to_wrap in TO_WRAP:
+            wrap_object = to_wrap.get("object")
+            unwrap(
+                f"openai.{wrap_object}",
+                to_wrap.get("method")
+            )

--- a/tests/test_openai_instrumentation.py
+++ b/tests/test_openai_instrumentation.py
@@ -421,69 +421,69 @@ class TestOpenAIInstrumentation(TestBase):
             self.assertEqual(span.attributes[f"{name}.input"], "I want to kill them.")
             self.assertEqual(span.attributes[f"{name}.response.id"], result["id"])
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.hate"],
+                span.attributes[f"{name}.response.results.0.categories.hate"],
                 result["results"][0]["categories"]["hate"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.hate/threatening"],
+                span.attributes[f"{name}.response.results.0.categories.hate/threatening"],
                 result["results"][0]["categories"]["hate/threatening"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.self-harm"],
+                span.attributes[f"{name}.response.results.0.categories.self-harm"],
                 result["results"][0]["categories"]["self-harm"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.sexual"],
+                span.attributes[f"{name}.response.results.0.categories.sexual"],
                 result["results"][0]["categories"]["sexual"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.sexual/minors"],
+                span.attributes[f"{name}.response.results.0.categories.sexual/minors"],
                 result["results"][0]["categories"]["sexual/minors"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.violence"],
+                span.attributes[f"{name}.response.results.0.categories.violence"],
                 result["results"][0]["categories"]["violence"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.categories.violence/graphic"],
+                span.attributes[f"{name}.response.results.0.categories.violence/graphic"],
                 result["results"][0]["categories"]["violence/graphic"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.category_scores.hate"],
+                span.attributes[f"{name}.response.results.0.category_scores.hate"],
                 result["results"][0]["category_scores"]["hate"],
             )
             self.assertEqual(
                 span.attributes[
-                    f"{name}.response.results.category_scores.hate/threatening"
+                    f"{name}.response.results.0.category_scores.hate/threatening"
                 ],
                 result["results"][0]["category_scores"]["hate/threatening"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.category_scores.self-harm"],
+                span.attributes[f"{name}.response.results.0.category_scores.self-harm"],
                 result["results"][0]["category_scores"]["self-harm"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.category_scores.sexual"],
+                span.attributes[f"{name}.response.results.0.category_scores.sexual"],
                 result["results"][0]["category_scores"]["sexual"],
             )
             self.assertEqual(
                 span.attributes[
-                    f"{name}.response.results.category_scores.sexual/minors"
+                    f"{name}.response.results.0.category_scores.sexual/minors"
                 ],
                 result["results"][0]["category_scores"]["sexual/minors"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.category_scores.violence"],
+                span.attributes[f"{name}.response.results.0.category_scores.violence"],
                 result["results"][0]["category_scores"]["violence"],
             )
             self.assertEqual(
                 span.attributes[
-                    f"{name}.response.results.category_scores.violence/graphic"
+                    f"{name}.response.results.0.category_scores.violence/graphic"
                 ],
                 result["results"][0]["category_scores"]["violence/graphic"],
             )
             self.assertEqual(
-                span.attributes[f"{name}.response.results.flagged"],
+                span.attributes[f"{name}.response.results.0.flagged"],
                 result["results"][0]["flagged"],
             )
 


### PR DESCRIPTION
## What does this PR do?

Big Changes:
1. Instead of instrumenting each kind of API call in its own separate `_instrument_*()` function, adds a common `_wrap()` function that instruments each API call type listed in the new `TO_WRAP` dict. The hope is that this will make the code easier to maintain moving forward, since it makes "what does instrumentation mean" common across all the api calls, and it makes "what is getting instrumented" effectively just a series of configurations that can be tweaked and added to as necessary. 
2. Changes the `openai.Moderation.create()` instrumentation to support multiple response values (and changes the underlying test expectations)

Small Changes:
1. doesn't import all of `wrapt`, just the `wrap_function_wrapper` that we need. 
2. removes `Tracer` from `opentelemetry.trace` import, since we don't really need it?
4. swaps `math.inf` for the equivalent `float('inf')` so that we can drop the `math` import altogether.

## Motivation

* Hopefully easier to review / maintain for future readers / contributors
* Support more uses of `Moderation.create()`

## Testing

Tests pass locally, and the spans i captured in console matched my expectations. 